### PR TITLE
It is better to use the repository field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "lnd"
 version = "0.1.4"
 edition = "2021"
 description = "Utility to run a regtest lnd process connected to a given bitcoind instance, useful in integration testing environment."
-homepage = "https://github.com/bennyhodl/lnd-test-util"
+repository = "https://github.com/bennyhodl/lnd-test-util"
 license = "MIT"
 
 [features]


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.